### PR TITLE
Fix iOS simulator flags in README.md to match `hello-pear`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ By default the helpers builds bare for every architecture for both iOS and Andro
 
 ```sh
 # iOS simulator only
-hello-pear --ios-simulator
+hello-pear --ios-sim
 
 # iOS and iOS simulator
-hello-pear --ios --ios-simulator
+hello-pear --ios --ios-sim
 
 # Android only arm archs
 hello-pear --android arm64 arm


### PR DESCRIPTION
Got `error: unknown option '--ios-simulator'` when running `npx hello-pear --ios --ios-simulator -c` and noticed the flags were different in `bin/hello-pear.js`.