### PR TITLE
Fix support x64 ios simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ For ease we added a helper script you can simply install running `npm link` in t
 By default the helpers builds bare for every architecture for both iOS and Android, but a more fine grained build could be achieved:
 
 ```sh
-# iOS simulator only
-hello-pear --ios-sim
+# iOS simulator only arm64
+hello-pear --ios-sim arm64
+
+# iOS simulator only x64
+hello-pear --ios-sim x64
 
 # iOS and iOS simulator
-hello-pear --ios --ios-sim
+hello-pear --ios --ios-sim arm64
 
 # Android only arm archs
 hello-pear --android arm64 arm

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ By default the helpers builds bare for every architecture for both iOS and Andro
 
 ```sh
 # iOS simulator only
-hello-pear --ios-simulator
+hello-pear --ios-sim
 
 # iOS and iOS simulator
-hello-pear --ios --ios-simulator
+hello-pear --ios --ios-sim
 
 # Android only arm archs
 hello-pear --android arm64 arm

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ For ease we added a helper script you can simply install running `npm link` in t
 By default the helpers builds bare for every architecture for both iOS and Android, but a more fine grained build could be achieved:
 
 ```sh
-# iOS simulator only arm64
-hello-pear --ios-sim arm64
+# iOS simulator only
+hello-pear --ios-sim
 
-# iOS simulator only x64
+# iOS simulator only with x64 architecture
 hello-pear --ios-sim x64
 
 # iOS and iOS simulator

--- a/bin/hello-pear.js
+++ b/bin/hello-pear.js
@@ -109,8 +109,7 @@ program
       }
       return { ...previous, [value]: true }
     },
-    // TODO Set this to default to match the current machines architecture
-    {}
+    iosSimArchs.indexOf(process.arch) !== -1 ? process.arch : 'arm64'
   )
   .option(
     '-a, --android <arch...>',

--- a/bin/hello-pear.js
+++ b/bin/hello-pear.js
@@ -31,7 +31,8 @@ const cmakeInstall = (buildOptions) => {
 
 const BUILD = path.join(__dirname, '..', 'build')
 const buildOptionsIos = { build: `${BUILD}/ios-arm64` }
-const buildOptionsIosSimulator = { build: `${BUILD}/ios-arm64-simulator` }
+const buildOptionsIosArm64Simulator = { build: `${BUILD}/ios-arm64-simulator` }
+const buildOptionsIosX64Simulator = { build: `${BUILD}/ios-x64-simulator` }
 const buildOptionsAndroidArm64 = { build: `${BUILD}/android-arm64` }
 const buildOptionsAndroidArm = { build: `${BUILD}/android-arm` }
 const buildOptionsAndroidX64 = { build: `${BUILD}/android-x64` }
@@ -44,11 +45,23 @@ const optionsIosCommon = {
   iosDeploymentTarget: 14
 }
 const optionsIos = { ...optionsIosCommon, ...buildOptionsIos }
-const optionsIosSimulator = {
+const optionsIosArm64Simulator = {
   ...optionsIosCommon,
-  ...buildOptionsIosSimulator,
+  ...buildOptionsIosArm64Simulator,
   simulator: true
 }
+
+const optionsIosX64Simulator = {
+  ...optionsIosCommon,
+  ...buildOptionsIosX64Simulator,
+  simulator: true,
+  arch: 'x64'
+}
+
+const iosSimArchs = [
+  optionsIosArm64Simulator.arch,
+  optionsIosX64Simulator.arch
+]
 
 const optionsAndroidCommon = {
   ...optionsCommon,
@@ -87,7 +100,18 @@ program
   .version(pkg.version)
   .option('-c, --configure', 'configure before', false)
   .option('-i, --ios', 'build + package for iOS')
-  .option('-s, --ios-sim', 'build + package for iOS simulator')
+  .option(
+    '-s, --ios-sim <arch...>',
+    'build + package for iOS simulator (arm64, x64)',
+    (value, previous) => {
+      if (iosSimArchs.findIndex((arch) => arch === value) < 0) {
+        throw new Error(`${value} is not a valid iOS simulator architecture`)
+      }
+      return { ...previous, [value]: true }
+    },
+    // TODO Set this to default to match the current machines architecture
+    {}
+  )
   .option(
     '-a, --android <arch...>',
     'build + package for Android architectures (arm64, arm, x64, ia32)',
@@ -109,11 +133,12 @@ program
 async function action () {
   const options = program.opts()
 
-  const hasDarwin = options.ios === true || options.iosSim === true
+  const hasDarwin = options.ios === true || Object.keys(options.iosSim).length > 0
   const hasAndroid = Object.keys(options.android).length > 0
 
   let ios = !hasDarwin && !hasAndroid ? true : options.ios === true
-  let iosSim = !hasDarwin && !hasAndroid ? true : options.iosSim === true
+  let iosSimArm64 = !hasDarwin && !hasAndroid ? true : options.iosSim.arm64 === true
+  let iosSimX64 = !hasDarwin && !hasAndroid ? true : options.iosSim.x64 === true
 
   let androidArm64 = !hasAndroid && !hasDarwin ? true : options.android.arm64 === true
   let androidArm = !hasAndroid && !hasDarwin ? true : options.android.arm === true
@@ -128,8 +153,11 @@ async function action () {
     if (ios) {
       commands.push(() => bareConfigure(optionsIos))
     }
-    if (iosSim) {
-      commands.push(() => bareConfigure(optionsIosSimulator))
+    if (iosSimArm64) {
+      commands.push(() => bareConfigure(optionsIosArm64Simulator))
+    }
+    if (iosSimX64) {
+      commands.push(() => bareConfigure(optionsIosX64Simulator))
     }
     if (androidArm64) {
       commands.push(() => bareConfigure(optionsAndroidArm64))
@@ -150,8 +178,11 @@ async function action () {
   if (ios) {
     commands.push(() => bareBuild(optionsIos))
   }
-  if (iosSim) {
-    commands.push(() => bareBuild(optionsIosSimulator))
+  if (iosSimArm64) {
+    commands.push(() => bareBuild(optionsIosArm64Simulator))
+  }
+  if (iosSimX64) {
+    commands.push(() => bareBuild(optionsIosX64Simulator))
   }
   if (androidArm64) {
     commands.push(() => bareBuild(optionsAndroidArm64))
@@ -171,8 +202,11 @@ async function action () {
   if (ios) {
     commands.push(() => cmakeInstall(buildOptionsIos))
   }
-  if (iosSim) {
-    commands.push(() => cmakeInstall(buildOptionsIosSimulator))
+  if (iosSimArm64) {
+    commands.push(() => cmakeInstall(buildOptionsIosArm64Simulator))
+  }
+  if (iosSimX64) {
+    commands.push(() => cmakeInstall(buildOptionsIosX64Simulator))
   }
   if (androidArm64) {
     commands.push(() => cmakeInstall(buildOptionsAndroidArm64))


### PR DESCRIPTION
I'm on an intel mac and got errors trying to build / start the example like the following:
```
› Linking   pearexpopearexpohelloworld » pearexpohelloworld
⚠️  ld: ignoring file ~/pear-expo-hello-world/modules/hello-bare/ios/../../../bare-libs/ios/iphonesimulator/libhello_bare.a, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
⚠️  ld: ignoring file ~/pear-expo-hello-world/modules/hello-bare/ios/../../../bare-libs/ios/iphonesimulator/misc/libc++.a, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
⚠️  ld: ignoring file ~/pear-expo-hello-world/modules/hello-bare/ios/../../../bare-libs/ios/iphonesimulator/libbare.a, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
⚠️  ld: ignoring file ~/pear-expo-hello-world/bare-libs/ios/iphonesimulator/libjs.a, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
⚠️  ld: ignoring file ~/pear-expo-hello-world/bare-libs/ios/iphonesimulator/libv8.a, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
⚠️  ld: Could not find or use auto-linked framework 'CoreAudioTypes'
❌  Undefined symbols for architecture x86_64
┌─ Symbol: _hb_get_data
└─ Referenced from: -[HelloBare install:] in libHelloBare.a(HelloBare.o)


❌  ld: symbol(s) not found for architecture x86_64



❌  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Noticed the `building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64` and that `arm64` was hardcoded in `hello-pear.js`. So tried adding architecture support in a similar way to how android is supported and was able to build / start the application.

This PR branches off of #3 .