### PR TITLE
A set of minor changes & clean up

### DIFF
--- a/bare/hello-bare.cc
+++ b/bare/hello-bare.cc
@@ -39,7 +39,7 @@ static struct {
   void* data;
 
 #if defined(__APPLE__)
-  os_log_t logger;
+  os_log_t logger = OS_LOG_DEFAULT;
 #endif
 } hb;
 

--- a/bare/hello-bare.cc
+++ b/bare/hello-bare.cc
@@ -98,7 +98,7 @@ static js_value_t* _runtime_send_message(js_env_t* env, js_callback_info_t* info
   assert(err == 0);
 
   uv_rwlock_rdlock(&hb.data_lock);
-  if (hb.on_log != nullptr) {
+  if (hb.on_message != nullptr) {
     hb.on_message(buf, len, hb.data);
   }
   uv_rwlock_rdunlock(&hb.data_lock);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "expo-hello-bare",
+  "name": "pear-expo-hello-world",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "expo-hello-bare",
+      "name": "pear-expo-hello-world",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "~18.2.45",
@@ -22,7 +22,7 @@
         "typescript": "^5.3.0"
       },
       "bin": {
-        "hello-bare": "bin/hello-bare.js"
+        "hello-pear": "bin/hello-pear.js"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",


### PR DESCRIPTION
Changes include:

- Updating `package-lock.json`
- Checking if `hb.on_message` instead of `hb.on_log` is a `nullptr` before calling `hb.on_message`  
   This is functionally no different as `on_log` is set at the same time, but checking `on_message` was likely the intent.
- Default `hb.logger` to `OS_LOG_DEFAULT` to fix logging on apple