### PR TITLE
[INTERNAL] upgrade expo to sdk 51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 node_modules/
 
+# Ruby / CocoaPods
+**/Pods/
+
 # Expo
 .expo/
 dist/
@@ -46,3 +49,11 @@ package-lock.json
 *.d
 /bare-build/
 /bare-libs/
+
+# Yarn
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/modules/hello-bare/android/src/main/java/to/holepunch/hellobare/HelloBareModule.kt
+++ b/modules/hello-bare/android/src/main/java/to/holepunch/hellobare/HelloBareModule.kt
@@ -2,11 +2,13 @@ package to.holepunch.hellopear
 
 import com.facebook.react.bridge.CatalystInstanceImpl
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.annotations.FrameworkAPI
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
 @Suppress("unused")
 class HelloBareModule : Module() {
+  @OptIn(FrameworkAPI::class)
   override fun definition() = ModuleDefinition {
     Name("HelloBare")
 

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "bare-process": "^1.3.2",
     "compact-encoding": "^2.13.0",
     "events": "npm:bare-node-events",
-    "expo": "~50.0.6",
-    "expo-build-properties": "~0.11.1",
-    "expo-status-bar": "~1.11.1",
+    "expo": "^51.0.31",
+    "expo-build-properties": "~0.12.5",
+    "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
-    "react-native": "0.73.4",
+    "react-native": "0.74.5",
     "tiny-buffer-rpc": "^2.0.1",
-    "typescript": "^5.3.0"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
This pr aims to update expo sdk version to the latest.
After upgrading it running npm run ios and npm run android generates the updated native project for each respective mobile platform.
[Upgrade reference](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/)